### PR TITLE
Build things on ubuntu-20.04

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       matrix:
         os:
-          - ubuntu-latest
+          - ubuntu-20.04
           - macos-latest
     runs-on: ${{ matrix.os }}
     steps:
@@ -49,7 +49,7 @@ jobs:
     strategy:
       matrix:
         os:
-          - ubuntu-latest
+          - ubuntu-20.04
 # macos test fail with dist-built ipfs.
 #          - macos-latest
     runs-on: ${{ matrix.os }}
@@ -94,7 +94,7 @@ jobs:
   release:
     name: "Release"
     needs: test-artifacts
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
     - name: Download artifacts
       id: download

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -12,7 +12,7 @@ env:
 jobs:
   tests:
     name: "Compact denylist format test suite"
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
     - uses: actions/checkout@v3
       with:
@@ -33,7 +33,7 @@ jobs:
 
   check:
     name: "Static, syntax and spelling checks"
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
     - uses: actions/checkout@v3
       with:


### PR DESCRIPTION
This is what Kubo is built on and the plugin fails to load on ubuntu-20.04 due to GLIBC-version issues.