### PR TITLE
Handle IPNS names without dots

### DIFF
--- a/tester/tester.go
+++ b/tester/tester.go
@@ -265,10 +265,12 @@ func (s *Suite) testIPNSPath() error {
 	// rule6
 	rule6 := []string{
 		"/ipns/domain.example",
+		"/ipns/domain-example",
 	}
 	rule6allowed := []string{
 		"/ipns/domainaefa.example",
 		"/ipns/domain.example/path",
+		"/ipns/domain--example",
 	}
 
 	if err := s.testPaths(rule6, n, "rule6", false); err != nil {


### PR DESCRIPTION
When checking if an ipfs name is blocked, we may get an `/ipns/{dnslink_name}` where the `{dnslink_name}` has been encoded according to

https://specs.ipfs.tech/http-gateways/subdomain-gateway/#host-request-header

That is, "." has been replaced with "-" and "-" has been replaced with "--".

Because of this, when the given dns name has no dots, we undo things are replace "--" with "-" and "-" with ".".