### PR TITLE
Fix: doublehashes can use different hashes

### DIFF
--- a/denylist.go
+++ b/denylist.go
@@ -371,18 +371,19 @@ func (dl *Denylist) parseLine(line string, number uint64) error {
 		// It can be a Multihash (CIDv0) or a sha256-hex-encoded string.
 
 		var mhType uint64
-		// attempt to parse CID
+		// attempt to parse a b58btc-encoded multihash
 		rule = strings.TrimPrefix(rule, "//")
-		c, err := cid.Decode(rule)
+		mh, err := multihash.FromB58String(rule)
 		if err == nil {
-			prefix := c.Prefix()
-			if prefix.Version != 0 {
-				return fmt.Errorf("double-hash is not a raw-multihash (cidv0) (%s:%d)", dl.Filename, number)
+			dmh, err := multihash.Decode(mh)
+			if err != nil {
+				return fmt.Errorf("what appears to be a multihash b58 string cannot be decoded (%s:%d): %w", dl.Filename, number, err)
 			}
-			e.Multihash = c.Hash()
+
+			e.Multihash = mh
 			// we use the multihash codec to group double-hashes
 			// with the same hashing function.
-			mhType = c.Prefix().MhType
+			mhType = dmh.Code
 		} else { // Assume a hex-encoded sha256 string
 			bs, err := hex.DecodeString(rule)
 			if err != nil {

--- a/tester/test.deny
+++ b/tester/test.deny
@@ -78,4 +78,5 @@ author: "@hsanjuan"
 # (different codec)
 # And /ipfs/f01701e20903cf61d46521b05f926ba1634628d0bba8a7ffb5b6d5a3ca310682ca63b5ef0/path
 # But not /path2
-//QmbK7LDv5NNBvYQzNfm2eED17SNLt1yNMapcUhSuNLgkqz
+//gW813G35CnLsy7gRYYHuf63hrz71U1xoLFDVeV7actx6oX
+


### PR DESCRIPTION
Currently, we tried to parse double-hashes as CIDv0s, which implies that SHA256 was used to hash the double-hash. Instead we should try to parse a multihash directly, and support any hashing function for the double-hash.

The rule14 test has been changed to use a blake3 double-hash, which previously broke at the parsing level.