### PR TITLE
Improve support for IPNS double-hashed entries

### DIFF
--- a/cmd/nopfs/main.go
+++ b/cmd/nopfs/main.go
@@ -25,7 +25,7 @@ func printUsage() {
 }
 
 func main() {
-	logging.SetLogLevel("nopfs", "DEBUG")
+	logging.SetLogLevel("nopfs", "ERROR")
 	filename := "test.deny"
 	if len(os.Args) < 2 || os.Args[1] == "-h" || os.Args[1] == "--help" {
 		fmt.Println("nopfs: denylist testing REPL")

--- a/denylist.go
+++ b/denylist.go
@@ -825,7 +825,7 @@ func (dl *Denylist) isIPFSIPLDPathBlocked(cidStr, subpath, protocol string) Stat
 	v1b32 := cid.NewCidV1(prefix.Codec, c.Hash()).String() // base32 string
 	v1b32path := v1b32
 	// badbits appends / on empty subpath. and hashes that
-	// https://github.com/protocol/badbits.dwebops.pub/blob/main/badbits-lambda/helpers.py#L17
+	// https://specs.ipfs.tech/compact-denylist-format/#double-hash
 	v1b32path += "/" + subpath
 	status, entry, err = dl.checkDoubleHashWithFn("IsIPFSIPLDPathBlocked (legacy)", v1b32path, multihash.SHA2_256)
 	if status != StatusNotFound { // hit or error

--- a/denylist.go
+++ b/denylist.go
@@ -697,7 +697,7 @@ func (dl *Denylist) IsIPNSPathBlocked(name, subpath string) StatusResponse {
 	// slash) or "<cidV1b32>/" for ipns-key blocking
 	legacyKey := name + "/" + subpath
 	if c.Defined() { // we parsed a CID before
-		legacyCid := cid.NewCidV1(c.Prefix().Codec, c.Hash()).String()
+		legacyCid := cid.NewCidV1(c.Prefix().Codec, c.Hash()).StringOfBase(mbase.Base32)
 		legacyKey = legacyCid + "/" + subpath
 	}
 	status, entry, err = dl.checkDoubleHashWithFn("IsIPNSPathBlocked (legacy)", legacyKey, multihash.SHA2_256)

--- a/denylist.go
+++ b/denylist.go
@@ -934,7 +934,7 @@ func (dl *Denylist) IsCidBlocked(c cid.Cid) StatusResponse {
 	// the double-hash using multhash sha2-256
 	// then check that
 	prefix := c.Prefix()
-	b32 := cid.NewCidV1(prefix.Codec, c.Hash()).String() + "/" // yes, needed
+	b32 := cid.NewCidV1(prefix.Codec, c.Hash()).StringOfBase(mbase.Base32) + "/" // yes, needed
 	status, entry, err := dl.checkDoubleHashWithFn("IsCidBlocked (legacy)", b32, multihash.SHA2_256)
 	if status != StatusNotFound { // hit or error
 		return StatusResponse{

--- a/denylist.go
+++ b/denylist.go
@@ -822,7 +822,7 @@ func (dl *Denylist) isIPFSIPLDPathBlocked(cidStr, subpath, protocol string) Stat
 	// <cidv1base32>/<path>
 	// TODO: we should be able to disable this part with an Option
 	// or a hint for denylists not using it.
-	v1b32 := cid.NewCidV1(prefix.Codec, c.Hash()).String() // base32 string
+	v1b32 := cid.NewCidV1(prefix.Codec, c.Hash()).StringOfBase(mbase.Base32) // base32 string
 	v1b32path := v1b32
 	// badbits appends / on empty subpath. and hashes that
 	// https://specs.ipfs.tech/compact-denylist-format/#double-hash

--- a/subscription.go
+++ b/subscription.go
@@ -99,7 +99,7 @@ func (s *HTTPSubscriber) downloadAndAppend() error {
 	rangeHeader := fmt.Sprintf("bytes=%d-", localFileSize)
 	req.Header.Set("Range", rangeHeader)
 
-	logger.Debug("%s: requesting bytes from %d: %s", s.localFile, localFileSize, req.URL)
+	logger.Debugf("%s: requesting bytes from %d: %s", s.localFile, localFileSize, req.URL)
 
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {

--- a/tester/test.deny
+++ b/tester/test.deny
@@ -53,6 +53,16 @@ author: "@hsanjuan"
 # sha256(bafybeiefwqslmf6zyyrxodaxx4vwqircuxpza5ri45ws3y5a62ypxti42e/)
 # blocks only this cid
 //d9d295bde21f422d471a90f2a37ec53049fdf3e5fa3ee2e8f20e10003da429e7
+# Legacy IPNS hash block
+# /ipns/k51qzi5uqu5dixwsch9wpd9rolqby1m0uqj5hhxwtxal0dwltastfmh01dlniq
+# becomes CIDv1 bafzaajaiaejca3vrvdzmu4qntwa2pn6apsd4ug5k63ckdyhnd3g6vdvgvujdw62s
+# then sha256(bafzaajaiaejca3vrvdzmu4qntwa2pn6apsd4ug5k63ckdyhnd3g6vdvgvujdw62s/)
+# should block /ipns/<key> in any format
+//6ef262a67f2c7caa9722b0fe46aced2f1559c749eab2bcf2f2701f43f802e900
+# Legacy DNSLink hash block
+# sha256(very-bad-example.eth/)
+//fb5a70b1aade810d21e8195a0da05f40ebd099e4b4d6bf088dc604e4fcf34263
+
 
 # rule11
 # Legacy Path double-hash block
@@ -63,7 +73,7 @@ author: "@hsanjuan"
 //3f8b9febd851873b3774b937cce126910699ceac56e72e64b866f8e258d09572
 
 # rule12
-# Double hash CID block
+# Double hash CID
 # base58btc-sha256-multihash(QmVTF1yEejXd9iMgoRTFDxBv7HAz9kuZcQNBzHrceuK9HR)
 # This should block bafybeidjwik6im54nrpfg7osdvmx7zojl5oaxqel5cmsz46iuelwf5acja
 # and its CIDv0 form QmVTF1yEejXd9iMgoRTFDxBv7HAz9kuZcQNBzHrceuK9HR
@@ -81,6 +91,25 @@ author: "@hsanjuan"
 //gW813G35CnLsy7gRYYHuf63hrz71U1xoLFDVeV7actx6oX
 
 # rule14
+# Double hash IPNS blocks
+# /ipns/my.domain.com
+# becomes
+//QmX6zeaAb8mC285YbXe4ac7LmX3jvrHBiFrw8kNnCM1bk4
+# /ipns/my.domain2.com/path
+# should only block the specific path
+# and becomes
+//QmcwfDuZYijxztHVR7w71WtdDaETsrGUU3ARWbNiYD3Hhp
+# /ipns/k51qzi5uqu5dixwsch9wpd9rolqby1m0uqj5hhxwtxal0dwltastfmh01dabcd
+# is multihash 12D3KooWHGU91cJWKofZoHQ3hkVgs2c6WAJGxVCjMivwej9ufyuN
+# and hashed again becomes
+//QmdGtYErkPjfpUPjVMUypoX8XTE9PUTBBF6KE9AwWaBs1e
+# /ipns/k51qzi5uqu5dixwsch9wpd9rolqby1m0uqj5hhxwtxal0dwltastfmh01d1234/mypath
+# equivalent to /ipns/bafzaajaiaejca3vrvdzmu4qntwa2pn6apsd4ug5k63ckdyhnd3g6vdvgvujczuoq/mypath
+# is multihash 12D3KooWHGU91cJWKofZoHQ3hkVgs2c6WAJGxVCjMivwej9udmWo/mypath
+# and hashed again becomes
+//QmQouNeftXbxGRt4U8s838diCuMPPHCfpHTR5w8bRREs9d
+
+# rule15
 # These are known cids corresponding to empty blocks/folders
 # Even if they appear here, they should not be blocked
 # empty unixfs directory

--- a/tester/tester.go
+++ b/tester/tester.go
@@ -139,7 +139,7 @@ func (s *Suite) testCID() error {
 		cid.MustParse("QmesfgDQ3q6prBy2Kg2gKbW4MAGuWiRP2DVuGA5MZSERLo"),
 	}
 
-	// rule14
+	// rule15
 	allowCids := []cid.Cid{
 		cid.MustParse("QmUNLLsPACCz1vLxQVkXqqLX5R1X345qqfHbsf67hvA3Nn"),
 		cid.MustParse("bafyaabakaieac"),
@@ -158,7 +158,7 @@ func (s *Suite) testCID() error {
 
 	for _, c := range allowCids {
 		if s.b.IsCidBlocked(c) {
-			return fmt.Errorf("testCID: %s should NOT be blocked (rule14)", c)
+			return fmt.Errorf("testCID: %s should NOT be blocked (rule15)", c)
 		}
 	}
 	return nil
@@ -338,6 +338,15 @@ func (s *Suite) testDoubleHashLegacy() error {
 	if !s.b.IsCidBlocked(c) {
 		return fmt.Errorf("%s: cid %s should be blocked (rule10)", n, c)
 	}
+	rule10 := []string{
+		"/ipns/k51qzi5uqu5dixwsch9wpd9rolqby1m0uqj5hhxwtxal0dwltastfmh01dlniq",
+		"/ipns/bafzaajaiaejca3vrvdzmu4qntwa2pn6apsd4ug5k63ckdyhnd3g6vdvgvujdw62s",
+		"/ipns/very-bad-example.eth",
+		"/ipns/very-bad-example.eth/",
+	}
+	if err := s.testPaths(rule10, n, "rule10", false); err != nil {
+		return err
+	}
 
 	//rule 11 (and 10)
 	rule11 := []string{
@@ -393,6 +402,27 @@ func (s *Suite) testDoubleHash() error {
 	}
 
 	if err := s.testPaths(rule13allowed, n, "rule13", true); err != nil {
+		return err
+	}
+
+	// rule14
+	rule14 := []string{
+		"/ipns/my.domain.com",
+		"/ipns/my.domain2.com/path",
+		"/ipns/k51qzi5uqu5dixwsch9wpd9rolqby1m0uqj5hhxwtxal0dwltastfmh01dabcd",
+		"/ipns/k51qzi5uqu5dixwsch9wpd9rolqby1m0uqj5hhxwtxal0dwltastfmh01d1234/mypath",
+		"/ipns/bafzaajaiaejca3vrvdzmu4qntwa2pn6apsd4ug5k63ckdyhnd3g6vdvgvujczuoq/mypath",
+	}
+	rule14allowed := []string{
+		"/ipns/my.domain2.com/path2",
+		"/ipns/k51qzi5uqu5dixwsch9wpd9rolqby1m0uqj5hhxwtxal0dwltastfmh01d1234/mypath2",
+	}
+
+	if err := s.testPaths(rule14, n, "rule14", false); err != nil {
+		return err
+	}
+
+	if err := s.testPaths(rule14allowed, n, "rule14", true); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
Fixes #40. This ensures that double-hashed IPNS entries both in modern and legacy forms are correctly supported, including both:
  * `/ipns/<domain>` 
  * `/ipns/key`

Before, only the modern form with /ipns/<domain> was correctly supported for double-hashed entries.

Testcases have been added for all forms.

The double-hashing check code that was duplicated in several functions has been consolidated.