### PR TITLE
Fix error when no doublehash db exists

### DIFF
--- a/denylist.go
+++ b/denylist.go
@@ -620,7 +620,7 @@ func toDNSLinkFQDN(label string) string {
 func (dl *Denylist) checkDoubleHashWithFn(caller string, origKey string, code uint64) (Status, Entry, error) {
 	blocksdb, ok := dl.DoubleHashBlocksDB[code]
 	if !ok {
-		return StatusErrored, Entry{}, fmt.Errorf("no DoubleHashBlocksDB for code %d", code)
+		return StatusNotFound, Entry{}, nil
 	}
 	// Double-hash the key
 	doubleHash, err := multihash.Sum([]byte(origKey), code, -1)


### PR DESCRIPTION
This was introduced after the refactor here: db000150a308129ce0b43f061a56fb2bee8e547a.

Before, we did not error when a double-hash db does not exist (meaning there are no entries in it). This goes back to that behaviour.