### PR TITLE
fix: Avoid scanning files outside of the project

### DIFF
--- a/nopfs-kubo-plugin/Makefile
+++ b/nopfs-kubo-plugin/Makefile
@@ -1,4 +1,4 @@
-SRC := $(shell find ../.. -type f -name '*.go')
+SRC := $(shell find .. -type f -name '*.go')
 IPFS_PATH ?= $(HOME)/.ipfs
 
 export CGO_ENABLED := 1


### PR DESCRIPTION
When trying to build in a docker environment, under the folder /app/, I was suprised to find out it scanned ALL the files of the filesystem. I eventually found out that this find command got one step too far in the parent hierarchy, scanning / instead of /app/.